### PR TITLE
Fix bug for multiply connected geometries

### DIFF
--- a/proptest-regressions/trapezoidal_map/trap_map.txt
+++ b/proptest-regressions/trapezoidal_map/trap_map.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 55b757015abd95efa2a7e7371391dbad6fc79ea310b12d548bb27d9b8fd4df5f # shrinks to points = [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [1.7154585492172678, 7.901363156842617]]


### PR DESCRIPTION
We were only storing a single face per edge, namely the one we were traversing when we met the edge.
As a consequence, trapezoids that were contained inside of a hole in the domain had both top and bottom edges with an assigned face, and thus points in those trapezoids are considered to be located in a neighboring face while they should be considered outside of all the faces. For these points, we should actually return `None`.

To fix it, we need to store for each edge the face above and the face below, and they are both optional. That way, we can represent the fact that an edge may have a face above but not below and vice versa.

Another added benefit is that we can check the consistency of the trap map by checking that the face above the bottom edge, and the face below the top edge of a trapezoid are the same.